### PR TITLE
Add basic metadata for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,9 @@
 name = "ufotofu_queues"
 version = "0.1.0"
 edition = "2021"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/worm-blossom/ufotofu_queues"
+description = "Infallible queues that support bulk enqueueing and dequeueing"
 
 [dependencies]


### PR DESCRIPTION
Adds manifest data for the following fields:

 - readme
 - license
 - repository
 - description

This is in preparation for publishing to crates.io.